### PR TITLE
Disable Percy when PERCY_ENABLE=0, or missing PERCY_TOKEN

### DIFF
--- a/src/Percy.js
+++ b/src/Percy.js
@@ -17,6 +17,7 @@ class Percy {
   webUrl: ?string;
   loaders: FileSystemAssetLoader[];
   includeBase: boolean;
+  enabled: boolean;
 
   constructor({ loaders, includeBase }: { loaders: FileSystemAssetLoader[], includeBase: false }) {
     const token = process.env.PERCY_TOKEN;
@@ -27,6 +28,18 @@ class Percy {
     this.environment = new PercyEnvironment(process.env);
     this.loaders = loaders;
     this.includeBase = includeBase;
+
+    if (process.env.PERCY_ENABLE === '0') {
+      this.enabled = false;
+      // eslint-disable-next-line no-console
+      console.log('Percy is disabled, due to PERCY_ENABLE being set to 0.');
+    } else if (!process.env.PERCY_TOKEN || !process.env.PERCY_PROJECT) {
+      this.enabled = false;
+      // eslint-disable-next-line no-console
+      console.log('Percy is disabled, due to missing PERCY_TOKEN or PERCY_PROJECT.');
+    } else {
+      this.enabled = true;
+    }
   }
 
   /*
@@ -41,6 +54,10 @@ class Percy {
       minimumHeight?: number,
     } = {},
   ): Promise<void> {
+    if (!this.enabled) {
+      return;
+    }
+
     if (!this.buildId) {
       return;
     }
@@ -92,6 +109,10 @@ class Percy {
      * Start a new build.
      */
   async startBuild(): Promise<void> {
+    if (!this.enabled) {
+      return;
+    }
+
     if (this.buildId) {
       throw new Error('There is already an active build, call percy.finalizeBuild() first');
     }
@@ -119,6 +140,10 @@ class Percy {
      * Commit the build as finalized.
      */
   async finalizeBuild(): Promise<void> {
+    if (!this.enabled) {
+      return;
+    }
+
     if (!this.buildId) {
       throw new Error('No build started, call percy.startBuild() first');
     }

--- a/src/Percy.js
+++ b/src/Percy.js
@@ -33,10 +33,10 @@ class Percy {
       this.enabled = false;
       // eslint-disable-next-line no-console
       console.log('Percy is disabled, due to PERCY_ENABLE being set to 0.');
-    } else if (!process.env.PERCY_TOKEN || !process.env.PERCY_PROJECT) {
+    } else if (!process.env.PERCY_TOKEN) {
       this.enabled = false;
       // eslint-disable-next-line no-console
-      console.log('Percy is disabled, due to missing PERCY_TOKEN or PERCY_PROJECT.');
+      console.log('Percy is disabled, due to missing PERCY_TOKEN.');
     } else {
       this.enabled = true;
     }


### PR DESCRIPTION
This introduces compatibility with our other clients, allowing Percy to be disabled, and prevents it from interfering with the process when it is disabled.

Percy will be disabled if PERCY_ENABLE=0, or if PERCY_TOKEN or PERCY_PROJECT are missing.