### PR TITLE
Update strict csp logging

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -32,7 +32,7 @@ export async function percySnapshot(page: Page, name: string, options: any = {})
   } catch (err) {
     // Certain CSP settings prevent Puppeteer from injecting scripts. See:
     // https://github.com/GoogleChrome/puppeteer/issues/2644
-    console.log(`[percy] Could not snapshot, maybe due to stringent CSPs. Try page.setBypassCSP(true).`)
+    console.log(`[percy] Could not take snapshot named '${name}', maybe due to stringent CSPs. Try page.setBypassCSP(true).`)
     return
   }
 

--- a/tests/sdk_spec.js
+++ b/tests/sdk_spec.js
@@ -96,6 +96,7 @@ describe('@percy/puppeteer SDK', function() {
       await percySnapshot(page, this.test.fullTitle(), {
         widths: [768, 992, 1200],
       })
+      await page.setBypassCSP(false)
     })
 
     // The CSP on Github as of 2/4/2019 is strict enough that we can't inject

--- a/tests/sdk_spec.js
+++ b/tests/sdk_spec.js
@@ -91,6 +91,7 @@ describe('@percy/puppeteer SDK', function() {
     })
 
     it('snapshots website with strict CSP', async function() {
+      await page.setBypassCSP(true)
       await page.goto('https://buildkite.com/')
       await percySnapshot(page, this.test.fullTitle(), {
         widths: [768, 992, 1200],


### PR DESCRIPTION
When a page with strict CSP is encountered, include the snapshot name in the logs.

Also, update the test snapshot of buildkite to reflect their CSP changes.