### PR TITLE
Allow passing `domTransformation` to percyAgent.

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -40,8 +40,18 @@ export async function percySnapshot(page: Page, name: string, options: any = {})
     return
   }
 
-  const domSnapshot = await page.evaluate(function(name: string, options: any) {
-    const percyAgentClient = new PercyAgent({ handleAgentCommunication: false })
+  if (options.domTransformation) {
+    options.stringifiedDomTransformation = options.domTransformation.toString();
+  }
+
+  const domSnapshot = await page.evaluate(function(name: string, options:any) {
+    const percyAgentClient = new PercyAgent({
+      handleAgentCommunication: false,
+      // See here for uses and also caviats of this method of deserializing functions
+      // TLDR: `this` and named args will not be deserialized correctly with this method.
+      // https://stackoverflow.com/a/45676430
+      domTransformation: new Function('return ' + options.stringifiedDomTransformation)()
+    })
     return percyAgentClient.snapshot(name, options)
   }, name, options)
 

--- a/tests/sdk_spec.js
+++ b/tests/sdk_spec.js
@@ -81,6 +81,17 @@ describe('@percy/puppeteer SDK', function() {
       itemsLeft.should.eq('0 items left')
       await percySnapshot(page, `${this.test.fullTitle()} #2`)
     })
+
+    it('snapshots part of a page', async function() {
+      await percySnapshot(page, this.test.fullTitle(), {
+        domTransformation: (documentClone) => {
+          let footerElement = documentClone.querySelector('footer.info');
+          documentClone.querySelector('body').innerHTML = footerElement.outerHTML;
+
+          return documentClone;
+        }
+      })
+    })
   })
 
   describe('with live sites', async function() {


### PR DESCRIPTION
Percy agent accepts a `domTransformation` option in its constructor, but currently our puppeteer sdk is not passing it into the right place. It is currently passing it into the percySnapshot method, where it should be passed to the percyAgent constructor method. This PR passes it to the constructor method.

An extra piece of fun-ness for this PR is that puppeteer [does not allow passing non-serializable things into `page.evaluate`](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pageevaluatepagefunction-args). A function is not a serializable item, so to make it work, I've serialized the function in a tricky way and called it from within the `evaluate` callback. 
For simple functions, this should work fine. If folks want to pass in real fancy stuff, we can revisit. 