### PR TITLE
fix: require the SDK utils directly

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,5 @@
 import { clientInfo } from './environment'
-import { agentJsFilename, isAgentRunning, postSnapshot } from '@percy/agent'
+let { agentJsFilename, isAgentRunning, postSnapshot } = require('@percy/agent/dist/utils/sdk-utils')
 import { Page } from 'puppeteer'
 
 declare var PercyAgent: any;


### PR DESCRIPTION
Require these SDK util functions directly to avoid having to include them in the main `@percy/agent` bundle which causes issues as it mixes code that should go into the browser vs code that should run in node.

Related issue: https://github.com/percy/percy-cypress/issues/58