### PR TITLE
fix: Loosen `@percy/agent` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@percy/agent": "^0.4.0"
+    "@percy/agent": "~0"
   },
   "release": {
     "plugins": [


### PR DESCRIPTION
## What is this? 

This PR is just like the one opened on the Cypress SDK: https://github.com/percy/percy-cypress/pull/92

It allows us to resolve to all 0.x.x versions of agent. 