### PR TITLE
🐛 Fix TS Types

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@percy/cli": "^1.0.0-beta.18",
+    "@types/puppeteer": "^5.4.2",
     "cross-env": "^7.0.2",
     "eslint": "^7.18.0",
     "eslint-config-standard": "^14.1.1",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import * as Puppeteer from 'puppeteer-core/lib/cjs/puppeteer/common/Page';
+import * as Puppeteer from 'puppeteer';
 import { SnapshotOptions } from '@percy/core';
 
 export default function percySnapshot(

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,5 +1,5 @@
 import { expectType, expectError } from 'tsd';
-import * as Puppeteer from 'puppeteer-core/lib/cjs/puppeteer/common/Page';
+import * as Puppeteer from 'puppeteer';
 import percySnapshot from '.';
 
 declare const page: Puppeteer.Page;

--- a/yarn.lock
+++ b/yarn.lock
@@ -547,6 +547,13 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/puppeteer@^5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-5.4.2.tgz#80f3a1f54dedbbf750779716de81401549062072"
+  integrity sha512-yjbHoKjZFOGqA6bIEI2dfBE5UPqU0YGWzP+ipDVP1iGzmlhksVKTBVZfT3Aj3wnvmcJ2PQ9zcncwOwyavmafBw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/stack-utils@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"


### PR DESCRIPTION
## What is this?

We're currently trying to rely `puppeteer-core` for types, but these can't be trusted depending on the project being integrated into. We now do a general import of Puppeteer from the `puppeteer` package.

The user will have to provide the proper types from `@types/puppeteer` (which they should already have since they're using TypeScript).