### PR TITLE
✨ Update logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ async function percySnapshot(page, name, options) {
   if (!page) throw new Error('A Puppeteer `page` object is required.');
   if (!name) throw new Error('The `name` argument is required.');
   if (!(await utils.isPercyEnabled())) return;
+  let log = utils.logger('puppeteer');
 
   try {
     // Inject the DOM serialization script
@@ -33,8 +34,8 @@ async function percySnapshot(page, name, options) {
       name
     });
   } catch (err) {
-    utils.log('error', `Could not take DOM snapshot "${name}"`);
-    utils.log('error', err);
+    log.error(`Could not take DOM snapshot "${name}"`);
+    log.error(err);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "test:types": "tsd"
   },
   "dependencies": {
-    "@percy/sdk-utils": "^1.0.0-beta.28"
+    "@percy/sdk-utils": "^1.0.0-beta.30"
   },
   "peerDependencies": {
     "puppeteer": ">=1"
   },
   "devDependencies": {
-    "@percy/cli": "^1.0.0-beta.18",
+    "@percy/cli": "^1.0.0-beta.30",
     "@types/puppeteer": "^5.4.2",
     "cross-env": "^7.0.2",
     "eslint": "^7.18.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -43,26 +43,22 @@ describe('percySnapshot', () => {
   it('disables snapshots when the healthcheck fails', async () => {
     sdk.test.failure('/percy/healthcheck');
 
-    await sdk.stdio(async () => {
-      await percySnapshot(page, 'Snapshot 1');
-      await percySnapshot(page, 'Snapshot 2');
-    });
+    await percySnapshot(page, 'Snapshot 1');
+    await percySnapshot(page, 'Snapshot 2');
 
     expect(sdk.server.requests).toEqual([
       ['/percy/healthcheck']
     ]);
 
-    expect(sdk.stdio[2]).toEqual([]);
-    expect(sdk.stdio[1]).toEqual([
+    expect(sdk.logger.stderr).toEqual([]);
+    expect(sdk.logger.stdout).toEqual([
       '[percy] Percy is not running, disabling snapshots\n'
     ]);
   });
 
   it('posts snapshots to the local percy server', async () => {
-    await sdk.stdio(async () => {
-      await percySnapshot(page, 'Snapshot 1');
-      await percySnapshot(page, 'Snapshot 2');
-    });
+    await percySnapshot(page, 'Snapshot 1');
+    await percySnapshot(page, 'Snapshot 2');
 
     expect(sdk.server.requests).toEqual([
       ['/percy/healthcheck'],
@@ -79,18 +75,17 @@ describe('percySnapshot', () => {
       })]
     ]);
 
-    expect(sdk.stdio[2]).toEqual([]);
+    expect(sdk.logger.stdout).toEqual([]);
+    expect(sdk.logger.stderr).toEqual([]);
   });
 
   it('handles snapshot failures', async () => {
     sdk.test.failure('/percy/snapshot', 'failure');
 
-    await sdk.stdio(async () => {
-      await percySnapshot(page, 'Snapshot 1');
-    });
+    await percySnapshot(page, 'Snapshot 1');
 
-    expect(sdk.stdio[1]).toHaveLength(0);
-    expect(sdk.stdio[2]).toEqual([
+    expect(sdk.logger.stdout).toEqual([]);
+    expect(sdk.logger.stderr).toEqual([
       '[percy] Could not take DOM snapshot "Snapshot 1"\n',
       '[percy] Error: failure\n'
     ]);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "dom"
+    ]
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -176,15 +176,6 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@dabh/diagnostics@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.2.tgz#290d08f7b381b8f94607dc8f471a12c675f9db31"
-  integrity sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==
-  dependencies:
-    colorspace "1.1.x"
-    enabled "2.0.x"
-    kuler "^2.0.0"
-
 "@eslint/eslintrc@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.3.0.tgz#d736d6963d7003b6514e6324bec9c602ac340318"
@@ -348,143 +339,144 @@
   resolved "https://registry.yarnpkg.com/@oclif/screen/-/screen-1.0.4.tgz#b740f68609dfae8aa71c3a6cab15d816407ba493"
   integrity sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==
 
-"@percy/cli-build@^1.0.0-beta.18":
-  version "1.0.0-beta.18"
-  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.0.0-beta.18.tgz#afafba27d4569ea48d8e82410f243d2d17deab40"
-  integrity sha512-Z8D7roky6dFQ6hhiCWOlc7hlvt2DHcxp+qHoVu91R7eJX7n+vHBCUY3XxmsKyrNtnanANhVIgRLM32GLDQr0EA==
+"@percy/cli-build@^1.0.0-beta.30":
+  version "1.0.0-beta.30"
+  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.0.0-beta.30.tgz#1ead1d040ac054a713ef18e3493f8273a1062e89"
+  integrity sha512-dakjUxYUF+xAC3KTBV3hQjzoeMqpW+Bgd9RoJYFp8g0Jd1izFmceCe/siTSEd8KnjfAqGwaZPaxNLLGt8VA3oA==
   dependencies:
-    "@percy/cli-command" "^1.0.0-beta.18"
-    "@percy/client" "^1.0.0-beta.18"
-    "@percy/env" "^1.0.0-beta.18"
-    "@percy/logger" "^1.0.0-beta.18"
+    "@percy/cli-command" "^1.0.0-beta.30"
+    "@percy/client" "^1.0.0-beta.30"
+    "@percy/env" "^1.0.0-beta.30"
+    "@percy/logger" "^1.0.0-beta.30"
 
-"@percy/cli-command@^1.0.0-beta.18":
-  version "1.0.0-beta.18"
-  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.0.0-beta.18.tgz#41352f205dd5638f2029cdf15b2b07a0f895ec2e"
-  integrity sha512-L1DJG3YFzR9Xwq2FCwYnWjpbnK0bVKn3uTZncP5Js3DCHCy0uxMgqeMotEM/YqxzDD5SfOUP7grsoeG+eW84Ww==
+"@percy/cli-command@^1.0.0-beta.30":
+  version "1.0.0-beta.30"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.0.0-beta.30.tgz#6389a966fab5452f8c8d7af03d611e03c73a4dfe"
+  integrity sha512-HTRSVUKI0l9Gd6oK4flmya+eUfn4vMGMnSJjNnTr9L3DWsPGEwEgphz8HHaKOU+1HOXMuy1SG1k3dh5pb6tjCQ==
   dependencies:
     "@oclif/command" "^1.8.0"
     "@oclif/config" "^1.17.0"
     "@oclif/plugin-help" "^3.2.0"
-    "@percy/config" "^1.0.0-beta.18"
-    "@percy/logger" "^1.0.0-beta.18"
+    "@percy/config" "^1.0.0-beta.30"
+    "@percy/logger" "^1.0.0-beta.30"
 
-"@percy/cli-config@^1.0.0-beta.18":
-  version "1.0.0-beta.18"
-  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.0.0-beta.18.tgz#78da0aac4e14c056fca270ce47524a8e2b6c70c8"
-  integrity sha512-gQCCuyZIevCnTtAfycb3dFHJdt9tQCBJYdYDkUtb0/DAqPMHhci1FUhjF8nMnvsgA9eSZ+/Lfv50iH1a41rN9g==
+"@percy/cli-config@^1.0.0-beta.30":
+  version "1.0.0-beta.30"
+  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.0.0-beta.30.tgz#ca8171cf7b375f98a49aa2d1c9053bc4eb90e505"
+  integrity sha512-Y7Xu2EX5AEy7DE0ldgM0gVHODKnx97tANP6jnqN54UlSTXS9LA1fUwnuofMwjFNGS3e95tOGE78/cEg1GdiDNA==
   dependencies:
     "@oclif/command" "^1.8.0"
     "@oclif/config" "^1.17.0"
-    "@percy/config" "^1.0.0-beta.18"
-    "@percy/logger" "^1.0.0-beta.18"
+    "@percy/config" "^1.0.0-beta.30"
+    "@percy/core" "^1.0.0-beta.30"
+    "@percy/logger" "^1.0.0-beta.30"
     path-type "^4.0.0"
 
-"@percy/cli-exec@^1.0.0-beta.18":
-  version "1.0.0-beta.18"
-  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.0.0-beta.18.tgz#e8f435eb1f9945c3cf3708ee599713a19b346f2a"
-  integrity sha512-h5LcaeAUm7FHIH/KxYENKNtctYs70C8godURsSFLghOhQVrNA5D3HpKswrqNMuoCrP8VkgcuQ+dEa/AaiTqdnA==
+"@percy/cli-exec@^1.0.0-beta.30":
+  version "1.0.0-beta.30"
+  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.0.0-beta.30.tgz#1f413505f4e4e9ee426d667057e4db0ddeec3ce8"
+  integrity sha512-NYjNF3ENMmxRdwcj3QwKOIBe9+fY3vogZMZLq4jsz2rKy27POj1yjSgqGEz+66/FPZufmyKF5V9hNFYziswCTw==
   dependencies:
-    "@percy/cli-command" "^1.0.0-beta.18"
-    "@percy/core" "^1.0.0-beta.18"
-    "@percy/logger" "^1.0.0-beta.18"
+    "@percy/cli-command" "^1.0.0-beta.30"
+    "@percy/core" "^1.0.0-beta.30"
+    "@percy/logger" "^1.0.0-beta.30"
     cross-spawn "^7.0.3"
     which "^2.0.2"
 
-"@percy/cli-snapshot@^1.0.0-beta.18":
-  version "1.0.0-beta.18"
-  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.0.0-beta.18.tgz#5e298c3c7c4b631eed09bb2f1118abd8f62d4311"
-  integrity sha512-53Quy1d9cmL1fKkm0/74oMTGWdLfZwVYO4UUqRMb1wjd8i5hpvsuXXuctPGin4sI2NJOXan5xClnMfpquxiCNw==
+"@percy/cli-snapshot@^1.0.0-beta.30":
+  version "1.0.0-beta.30"
+  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.0.0-beta.30.tgz#b80357bf6979fec1bdb441b6ebe9f18fc3edbcdf"
+  integrity sha512-Moow5qRo2hHb6Z2TSlPLcA4YwWPy6KzR8yr6U555v4Rukv3LGz67ZvU40aOSBdxZ37je6Kvrf4j9OkYjLQ1x+w==
   dependencies:
-    "@percy/cli-command" "^1.0.0-beta.18"
-    "@percy/config" "^1.0.0-beta.18"
-    "@percy/core" "^1.0.0-beta.18"
-    "@percy/dom" "^1.0.0-beta.18"
-    "@percy/logger" "^1.0.0-beta.18"
+    "@percy/cli-command" "^1.0.0-beta.30"
+    "@percy/config" "^1.0.0-beta.30"
+    "@percy/core" "^1.0.0-beta.30"
+    "@percy/dom" "^1.0.0-beta.30"
+    "@percy/logger" "^1.0.0-beta.30"
     globby "^11.0.1"
     serve-handler "^6.1.3"
     yaml "^1.10.0"
 
-"@percy/cli-upload@^1.0.0-beta.18":
-  version "1.0.0-beta.18"
-  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.0.0-beta.18.tgz#e5b06fe6765d2530882867ce5a69d335b41b39e3"
-  integrity sha512-vp9CEXmVqojZeSrpJH711DBhsk/n+FB2Htwv35N3fr19wUsxLfvy48n/fJ9wg3Db3rcpIB5yuIy+n/EhQpiVuQ==
+"@percy/cli-upload@^1.0.0-beta.30":
+  version "1.0.0-beta.30"
+  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.0.0-beta.30.tgz#dd377664decd43c6470ea1803163266156fa7954"
+  integrity sha512-Jhur/Tg++cNQJ8xvKLWCvHNyOtmyRUQ1sYZiDvlbqGcVEQKs2YIM+IQbvWh4ictEeyxHNtT2sVlqQQCoZTdSNw==
   dependencies:
-    "@percy/cli-command" "^1.0.0-beta.18"
-    "@percy/client" "^1.0.0-beta.18"
-    "@percy/config" "^1.0.0-beta.18"
-    "@percy/logger" "^1.0.0-beta.18"
+    "@percy/cli-command" "^1.0.0-beta.30"
+    "@percy/client" "^1.0.0-beta.30"
+    "@percy/config" "^1.0.0-beta.30"
+    "@percy/logger" "^1.0.0-beta.30"
     globby "^11.0.1"
     image-size "^0.9.1"
 
-"@percy/cli@^1.0.0-beta.18":
-  version "1.0.0-beta.18"
-  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.0.0-beta.18.tgz#d8f6291e46881d907ed20a75d3a3238d731ff5e8"
-  integrity sha512-Ou6gFQnc/jXx/rAiQpWe5SGkapfW3jUL+S5oCIh2A37wAcfG97+CJqjC1o5L+d9E+wKmWpaD7Sm/9NdMVqb6OA==
+"@percy/cli@^1.0.0-beta.30":
+  version "1.0.0-beta.30"
+  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.0.0-beta.30.tgz#e44dee9d3bb005b987411cb280c466badf39fd5b"
+  integrity sha512-Sj9Yh+ww60TdnpPc6zltq8BODecKN6u30PtRpmbAJX/n/1mEGnID0L/CzhVoi38sySL4tiDqDS54oTgCivBxsA==
   dependencies:
     "@oclif/plugin-help" "^3.2.0"
     "@oclif/plugin-plugins" "^1.9.0"
-    "@percy/cli-build" "^1.0.0-beta.18"
-    "@percy/cli-config" "^1.0.0-beta.18"
-    "@percy/cli-exec" "^1.0.0-beta.18"
-    "@percy/cli-snapshot" "^1.0.0-beta.18"
-    "@percy/cli-upload" "^1.0.0-beta.18"
+    "@percy/cli-build" "^1.0.0-beta.30"
+    "@percy/cli-config" "^1.0.0-beta.30"
+    "@percy/cli-exec" "^1.0.0-beta.30"
+    "@percy/cli-snapshot" "^1.0.0-beta.30"
+    "@percy/cli-upload" "^1.0.0-beta.30"
 
-"@percy/client@^1.0.0-beta.18":
-  version "1.0.0-beta.18"
-  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.0.0-beta.18.tgz#3ef73d0140b84014826e5bf6873608a3e788518d"
-  integrity sha512-tAOhryt2UfOIDVyKJF2KTbmj8egxwFR0ACR2FK63NIY7ld/uedLH8GR2Xcn2EXusRBBhaU1htig5Krt4DL8Q0A==
+"@percy/client@^1.0.0-beta.30":
+  version "1.0.0-beta.30"
+  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.0.0-beta.30.tgz#87b15a3776e6ffc377c418796422668d5564b10b"
+  integrity sha512-JJTO6ooeMoL1lQfeVnVclx3SdpBsx28h/J1jL5OChK86/QwU6KNE/zVI5kmWUJzCfBz3Nv8Sehj7HFDJCbg17Q==
   dependencies:
-    "@percy/env" "^1.0.0-beta.18"
+    "@percy/env" "^1.0.0-beta.30"
 
-"@percy/config@^1.0.0-beta.18":
-  version "1.0.0-beta.18"
-  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.0.0-beta.18.tgz#d51e70764652f20ef5ca7570459b3b8aca7637f3"
-  integrity sha512-otvcYzbAsy+HFi3wDq/53zTX3gy4GICWG6eQLgNUMMy9ufbccXk41B3I04Lo+yWtC8KUffINcIkXD9Z2tg+7Ew==
+"@percy/config@^1.0.0-beta.30":
+  version "1.0.0-beta.30"
+  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.0.0-beta.30.tgz#63b6ac647185a651fc37c17f4180c08076794c2b"
+  integrity sha512-pISKhnBDbzmoCrlaOgAHxzO3vzuec6Yh5BB3fGWGVVa1SyR/Nj901oZXnuOUQG3k/Eb/pm1o2MGtShTWsyphPA==
   dependencies:
-    "@percy/logger" "^1.0.0-beta.18"
-    ajv "^6.12.5"
+    "@percy/logger" "^1.0.0-beta.30"
+    ajv "^7.0.3"
     cosmiconfig "^7.0.0"
-    deepmerge "^4.2.2"
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-"@percy/core@^1.0.0-beta.18":
-  version "1.0.0-beta.18"
-  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.0.0-beta.18.tgz#22351fb4fb8db8dcd4afc05d60f948194f89bb62"
-  integrity sha512-hiunjoXCnqSBK0s0maUbmJK1W8wpAlkbP8NoAbmastUhXwu2bWqfk4AV08J1GsrQLbv4u0Z9+YgN5sH4sxAVCA==
+"@percy/core@^1.0.0-beta.30":
+  version "1.0.0-beta.30"
+  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.0.0-beta.30.tgz#07ebb92daff117fe11a3fa799ddf98903a18f02b"
+  integrity sha512-fwzgDig5Xzm8QOYJxhU3R/avJfYQbyBaGjMHo8t/ddCHAqUPS2OiXxljArz9LArjtl48SWFQfF3dK50HAZBCyQ==
   dependencies:
-    "@percy/client" "^1.0.0-beta.18"
-    "@percy/dom" "^1.0.0-beta.18"
-    "@percy/logger" "^1.0.0-beta.18"
-    node-fetch "^2.6.1"
+    "@percy/client" "^1.0.0-beta.30"
+    "@percy/config" "^1.0.0-beta.30"
+    "@percy/dom" "^1.0.0-beta.30"
+    "@percy/logger" "^1.0.0-beta.30"
+    extract-zip "^2.0.1"
     progress "^2.0.3"
-    puppeteer-core "^5.3.1"
+    rimraf "^3.0.2"
+    ws "^7.4.1"
 
-"@percy/dom@^1.0.0-beta.18":
-  version "1.0.0-beta.18"
-  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.0.0-beta.18.tgz#2875fe18b9babef0b10f6a476251c99b80849de5"
-  integrity sha512-+U751uQ0NObPCMqmgyzod+LwliCJTL5aI8z3//NXEARg7AaFux1kuMN6NhMgSLx8zFObUNwMeQBuAHm4DNZxXA==
+"@percy/dom@^1.0.0-beta.30":
+  version "1.0.0-beta.30"
+  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.0.0-beta.30.tgz#2bee9c5cdedc6e3400336c6ab8071d1aab651691"
+  integrity sha512-MDMVaU8uvvsX/c3fqq6FOJv4msnIBSAHEGNaxt+29hwuc5MRMO08+hNnUhR/SMLUI0JrQg6tYWkLXhVmoewx5A==
 
-"@percy/env@^1.0.0-beta.18":
-  version "1.0.0-beta.18"
-  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.0.0-beta.18.tgz#115640d7cbfebec4759069a25b2380b9c8580766"
-  integrity sha512-TRav5e9X6hReaF/YxT5skGxkrdGepRJwZumhBm3eJRuprCE2oIkQZ8VEasGycaCh18NKXYO0vUDz2j58KiQTyg==
+"@percy/env@^1.0.0-beta.30":
+  version "1.0.0-beta.30"
+  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.0.0-beta.30.tgz#ee95d0c019ff0c2a95aaebc90659d10f85533d84"
+  integrity sha512-BVuGeAVqBlX+zr1bOPlK723vzSwwa61kE8zFkuVM47HhBwayO9z/K6CWSP7O7/U9MjVomhKrFDKVFk97MpJa+A==
   dependencies:
     dotenv "^8.2.0"
 
-"@percy/logger@^1.0.0-beta.18":
-  version "1.0.0-beta.18"
-  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.0.0-beta.18.tgz#9e8a53beb4cc1d60252ecc560fc6be0ae6be7c0c"
-  integrity sha512-3E7gkMk42VSHqmzzeB5I6yNYsPPF6dx0lFUqZZ01vdh68NhT5DgukT707I3D0nm0EfWOx+Cuwx5j7e/63dNXqg==
-  dependencies:
-    colors "^1.4.0"
-    winston "^3.3.3"
+"@percy/logger@^1.0.0-beta.30":
+  version "1.0.0-beta.30"
+  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.0.0-beta.30.tgz#3d19f305cbcb24c058461320bba1ef4660aea4a5"
+  integrity sha512-Q6VHdDh4UfzCyl33D2Fu8rhqi7o700deGNZ2b7CdtscyFd6CHS8cfkuXX5qLHxWLHpdlQjema7gHd03U+jY7fg==
 
-"@percy/sdk-utils@^1.0.0-beta.28":
-  version "1.0.0-beta.28"
-  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.0.0-beta.28.tgz#73851d0bfa774c9978c25b23fce555f8bbead085"
-  integrity sha512-SkEyupAYZKTqMlfcvePFiwqfGy5wiXkKXzlXq1KRVOc+wudLZvHMdXRsoZrpNggLR2abiZf0yDchKBLkTkgFEw==
+"@percy/sdk-utils@^1.0.0-beta.30":
+  version "1.0.0-beta.30"
+  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.0.0-beta.30.tgz#71332d3839d89ad22f5c575e1b977aa13165628c"
+  integrity sha512-fNZijevFzzZbVL9zlnNP75zAuj9oRtSlbHKgIpMl9dviMb+zht2yFzUqioTz7hGZgc2SrF5YOcDva4rAU8SRwQ==
+  dependencies:
+    "@percy/logger" "^1.0.0-beta.30"
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -606,7 +598,7 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ajv@^6.10.0, ajv@^6.12.4, ajv@^6.12.5:
+ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.5"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.5.tgz#19b0e8bae8f476e5ba666300387775fb1a00a4da"
   integrity sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==
@@ -616,7 +608,7 @@ ajv@^6.10.0, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^7.0.2:
+ajv@^7.0.2, ajv@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-7.0.3.tgz#13ae747eff125cafb230ac504b2406cf371eece2"
   integrity sha512-R50QRlXSxqXcQP5SvKUrw8VZeypvo12i2IX0EeR5PiZ7bEKeHWgzgo264LDadUsCU42lTJVhFikTqJwNeH34gQ==
@@ -743,11 +735,6 @@ astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
-
-async@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
-  integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
 
 at-least-node@^1.0.0:
   version "1.0.0"
@@ -1017,7 +1004,7 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
-color-convert@^1.9.0, color-convert@^1.9.1:
+color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -1036,39 +1023,15 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@^1.0.0, color-name@~1.1.4:
+color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-color-string@^1.5.2:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.3.tgz#c9bbc5f01b58b5492f3d6857459cb6590ce204cc"
-  integrity sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==
-  dependencies:
-    color-name "^1.0.0"
-    simple-swizzle "^0.2.2"
-
-color@3.0.x:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/color/-/color-3.0.0.tgz#d920b4328d534a3ac8295d68f7bd4ba6c427be9a"
-  integrity sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==
-  dependencies:
-    color-convert "^1.9.1"
-    color-string "^1.5.2"
-
-colors@^1.1.2, colors@^1.2.1, colors@^1.4.0:
+colors@^1.1.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
-
-colorspace@1.1.x:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.2.tgz#e0128950d082b86a2168580796a0aa5d6c68d8c5"
-  integrity sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==
-  dependencies:
-    color "3.0.x"
-    text-hex "1.0.x"
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -1113,11 +1076,6 @@ convert-source-map@^1.7.0:
   integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
   dependencies:
     safe-buffer "~5.1.1"
-
-core-util-is@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-  integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
 cosmiconfig@^7.0.0:
   version "7.0.0"
@@ -1211,11 +1169,6 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-deepmerge@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
-  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
-
 default-require-extensions@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-3.0.0.tgz#e03f93aac9b2b6443fc52e5e4a37b3ad9ad8df96"
@@ -1298,11 +1251,6 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
-
-enabled@2.0.x:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
-  integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
 
 end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
@@ -1610,7 +1558,7 @@ extract-stack@^2.0.0:
   resolved "https://registry.yarnpkg.com/extract-stack/-/extract-stack-2.0.0.tgz#11367bc865bfcd9bc0db3123e5edb57786f11f9b"
   integrity sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ==
 
-extract-zip@^2.0.0:
+extract-zip@^2.0.0, extract-zip@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
   integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
@@ -1648,11 +1596,6 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fast-safe-stringify@^2.0.4:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
-  integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
-
 fast-url-parser@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/fast-url-parser/-/fast-url-parser-1.1.3.tgz#f4af3ea9f34d8a271cf58ad2b3759f431f0b318d"
@@ -1673,11 +1616,6 @@ fd-slicer@~1.1.0:
   integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
   dependencies:
     pend "~1.2.0"
-
-fecha@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.0.tgz#3ffb6395453e3f3efff850404f0a59b6747f5f41"
-  integrity sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg==
 
 file-entry-cache@^6.0.0:
   version "6.0.0"
@@ -1749,11 +1687,6 @@ flatted@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
-
-fn.name@1.x.x:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
-  integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
 foreground-child@^2.0.0:
   version "2.0.0"
@@ -2076,11 +2009,6 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
-is-arrayish@^0.3.1:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
-  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
-
 is-binary-path@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
@@ -2226,7 +2154,7 @@ is-yarn-global@^0.3.0:
   resolved "https://registry.yarnpkg.com/is-yarn-global/-/is-yarn-global-0.3.0.tgz#d502d3382590ea3004893746754c89139973e232"
   integrity sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==
 
-isarray@^1.0.0, isarray@~1.0.0:
+isarray@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
@@ -2432,11 +2360,6 @@ kind-of@^6.0.3:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
-kuler@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
-  integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
-
 latest-version@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face"
@@ -2544,17 +2467,6 @@ log-symbols@4.0.0, log-symbols@^4.0.0:
   integrity sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==
   dependencies:
     chalk "^4.0.0"
-
-logform@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/logform/-/logform-2.2.0.tgz#40f036d19161fc76b68ab50fdc7fe495544492f2"
-  integrity sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==
-  dependencies:
-    colors "^1.2.1"
-    fast-safe-stringify "^2.0.4"
-    fecha "^4.2.0"
-    ms "^2.1.1"
-    triple-beam "^1.3.0"
 
 lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
   version "1.0.1"
@@ -2697,7 +2609,7 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@2.1.2, ms@^2.1.1:
+ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -2721,11 +2633,6 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-
-node-fetch@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-preload@^0.2.1:
   version "0.2.1"
@@ -2835,13 +2742,6 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
-
-one-time@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/one-time/-/one-time-1.0.0.tgz#e06bc174aed214ed58edede573b433bbf827cb45"
-  integrity sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==
-  dependencies:
-    fn.name "1.x.x"
 
 optionator@^0.9.1:
   version "0.9.1"
@@ -3099,11 +2999,6 @@ pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
-process-nextick-args@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
-  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
-
 process-on-spawn@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/process-on-spawn/-/process-on-spawn-1.0.0.tgz#95b05a23073d30a17acfdc92a440efd2baefdc93"
@@ -3145,23 +3040,6 @@ pupa@^2.0.1:
   integrity sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==
   dependencies:
     escape-goat "^2.0.0"
-
-puppeteer-core@^5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-5.3.1.tgz#1affb1738afac499416a7fd4ed2ed0c18577e88f"
-  integrity sha512-YE6c6FvHAFKQUyNTqFs78SgGmpcqOPhhmVfEVNYB4abv7bV2V+B3r72T3e7vlJkEeTloy4x9bQLrGbHHoKSg1w==
-  dependencies:
-    debug "^4.1.0"
-    devtools-protocol "0.0.799653"
-    extract-zip "^2.0.0"
-    https-proxy-agent "^4.0.0"
-    pkg-dir "^4.2.0"
-    progress "^2.0.1"
-    proxy-from-env "^1.0.0"
-    rimraf "^3.0.2"
-    tar-fs "^2.0.0"
-    unbzip2-stream "^1.3.3"
-    ws "^7.2.3"
 
 puppeteer@^5.2.1:
   version "5.3.1"
@@ -3254,19 +3132,6 @@ read-pkg@^5.2.0:
     normalize-package-data "^2.5.0"
     parse-json "^5.0.0"
     type-fest "^0.6.0"
-
-readable-stream@^2.3.7:
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
-  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
-    util-deprecate "~1.0.1"
 
 readable-stream@^3.1.1, readable-stream@^3.4.0:
   version "3.6.0"
@@ -3386,7 +3251,7 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -3468,13 +3333,6 @@ signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
-simple-swizzle@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
-  integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
-  dependencies:
-    is-arrayish "^0.3.1"
-
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -3542,11 +3400,6 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stack-trace@0.0.x:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
-  integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
-
 stack-utils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.2.tgz#5cf48b4557becb4638d0bc4f21d23f5d19586593"
@@ -3602,13 +3455,6 @@ string_decoder@^1.1.1:
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
-
-string_decoder@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
-  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
-  dependencies:
-    safe-buffer "~5.1.0"
 
 strip-ansi@^4.0.0:
   version "4.0.0"
@@ -3725,11 +3571,6 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
-text-hex@1.0.x:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
-  integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
-
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -3761,11 +3602,6 @@ trim-newlines@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.0.tgz#79726304a6a898aa8373427298d54c2ee8b1cb30"
   integrity sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==
-
-triple-beam@^1.2.0, triple-beam@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
-  integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
 
 tsconfig-paths@^3.9.0:
   version "3.9.0"
@@ -3903,7 +3739,7 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-util-deprecate@^1.0.1, util-deprecate@~1.0.1:
+util-deprecate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
@@ -3958,29 +3794,6 @@ widest-line@^3.1.0:
   integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
   dependencies:
     string-width "^4.0.0"
-
-winston-transport@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.4.0.tgz#17af518daa690d5b2ecccaa7acf7b20ca7925e59"
-  integrity sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==
-  dependencies:
-    readable-stream "^2.3.7"
-    triple-beam "^1.2.0"
-
-winston@^3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-3.3.3.tgz#ae6172042cafb29786afa3d09c8ff833ab7c9170"
-  integrity sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==
-  dependencies:
-    "@dabh/diagnostics" "^2.0.2"
-    async "^3.1.0"
-    is-stream "^2.0.0"
-    logform "^2.2.0"
-    one-time "^1.0.0"
-    readable-stream "^3.4.0"
-    stack-trace "0.0.x"
-    triple-beam "^1.3.0"
-    winston-transport "^4.4.0"
 
 word-wrap@^1.2.3:
   version "1.2.3"
@@ -4047,6 +3860,11 @@ ws@^7.2.3:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.1.tgz#d0547bf67f7ce4f12a72dfe31262c68d7dc551c8"
   integrity sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==
+
+ws@^7.4.1:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.2.tgz#782100048e54eb36fe9843363ab1c68672b261dd"
+  integrity sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==
 
 xdg-basedir@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## What is this?

With percy/cli#140, better logging was implemented everywhere, including within the sdk-utils and it's test helper. Unfortunately, this is a breaking change that would cause the existing log methods to error if a newer version of the sdk-utils gets installed due to semver. 

This is a pre-emptive PR that will fail until a new version of the CLI is released with the new logger. Once that is released, this PR can be quickly updated and merged to minimize any incompatibility between beta versions.