### PR TITLE
🐛 Remove Dynamic import now that `@percy/sdk-utils` is commonjs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const utils = require('@percy/sdk-utils');
+
 // Collect client and environment information
 const sdkPkg = require('./package.json');
 const puppeteerPkg = require('puppeteer/package.json');
@@ -6,8 +8,6 @@ const ENV_INFO = `${puppeteerPkg.name}/${puppeteerPkg.version}`;
 
 // Take a DOM snapshot and post it to the snapshot endpoint
 async function percySnapshot(page, name, options) {
-  let utils = await import('@percy/sdk-utils');
-
   if (!page) throw new Error('A Puppeteer `page` object is required.');
   if (!name) throw new Error('The `name` argument is required.');
   if (!(await utils.isPercyEnabled())) return;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "puppeteer": ">=1"
   },
   "devDependencies": {
-    "@percy/core": "^1.0.0",
+    "@percy/core": "^1.1.2",
     "@types/puppeteer": "^5.4.2",
     "cross-env": "^7.0.2",
     "eslint": "^7.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -292,7 +292,7 @@
     cosmiconfig "^7.0.0"
     yaml "^2.0.0"
 
-"@percy/core@^1.0.0":
+"@percy/core@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.1.2.tgz#ab3cc069aada26d44dc9405631b60f09f6e444f1"
   integrity sha512-xAhC+sXPMtLITgpGWCXcoABVMFS3PprlnNTj9yZ8eYK+XGf80DweNuBEzxpKKlQCiN/f5N3TCnIYUJUVO6M6eA==
@@ -320,11 +320,6 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.1.2.tgz#73dfaa998da707d8881c669c11f02f1342cb44df"
   integrity sha512-rXwzCyBGY2or1s7alod3RxWvI9vKKSzFInv6A26fCTYRAHjIInl4aKNzaDzUnFk35fDtLPxnIS/QkgK2L4yLyw==
-
-"@percy/logger@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.1.0.tgz#6bb5df0563d3566071f8b718e61f11a04c5a2722"
-  integrity sha512-bAlxBcdnViTpGQZtjs361vXSlaxEj6Zt4Wt1Mo7EdPwv/zya2cBpLFNNcRycWto4mdb5Qnpht+IPXf7RFXJ/nw==
 
 "@percy/logger@1.1.2":
   version "1.1.2"


### PR DESCRIPTION
## What is this?

We converted `@percy/sdk-utils` to be ESM for 1.x, and this causes a lot of various issues. That has since been reverted (it's back to commonjs with https://github.com/percy/cli/pull/916) so we can remove the dynamic import to fully remove any issues with ESM.