### PR TITLE
chore: release 2.0.3-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/puppeteer",
   "description": "Pupppeteer client library for visual testing with Percy",
-  "version": "2.0.2",
+  "version": "2.0.3-beta.0",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-puppeteer",


### PR DESCRIPTION
Beta release: ships the PER-7348 readiness gate (waitForReady before serialize) via `@percy/sdk-utils@^1.31.15-beta.0`.

Merged in this line:
- #961 — readiness gate

Test plan:
- [ ] CI green
- [ ] npm dist-tag verified after merge + tag