### PR TITLE
chore: release 2.0.3-beta.1 (PER-7348 readiness fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/puppeteer",
   "description": "Pupppeteer client library for visual testing with Percy",
-  "version": "2.0.3-beta.0",
+  "version": "2.0.3-beta.1",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-puppeteer",
@@ -26,7 +26,7 @@
     "test:types": "tsd"
   },
   "dependencies": {
-    "@percy/sdk-utils": "^1.31.15-beta.0"
+    "@percy/sdk-utils": "^1.32.0-beta.6"
   },
   "peerDependencies": {
     "puppeteer": ">=1"


### PR DESCRIPTION
## What
Beta release **@percy/puppeteer@2.0.3-beta.1**.

- Bumps version `2.0.3-beta.0` → `2.0.3-beta.1`.
- Bumps `@percy/sdk-utils` → `^1.32.0-beta.6`, which carries the readiness-gate fix (page.evaluate SDKs no longer hit the *illegal top-level return* `SyntaxError` — cli#2247 / cli#2253).

## Release
Merge → publish a GitHub Release → `release.yml` runs `npm publish` → ships `@percy/puppeteer@2.0.3-beta.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)