### PR TITLE
security: harden CI workflows — pin actions, scope tokens, fix dispatch branch injection (PER-8741/8742/8743)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,10 +2,16 @@ name: Changelog
 on:
   push:
     branches: [master]
+permissions:
+  contents: read
+
 jobs:
   update_draft:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # v6.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,18 +1,21 @@
 name: Lint
 on: push
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: 14
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v3
+      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: v1/${{ runner.os }}/node-14/${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,19 +2,22 @@ name: Release
 on:
   release:
     types: [published]
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: 14
           registry-url: 'https://registry.npmjs.org'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v3
+      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: v1/${{ runner.os }}/node-14/${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,11 +3,17 @@ on:
   schedule:
     - cron: '0 19 * * 2'
 
+permissions:
+  contents: read
+
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
           stale-issue-message: >-
             This issue is stale because it has been open for more than 14 days with no activity.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
         required: false
         type: string
         default: master
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -16,7 +19,7 @@ jobs:
         node: [14]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions-ecosystem/action-regex-match@v2
+      - uses: actions-ecosystem/action-regex-match@9e6c4fb3d5e898f505be7a1fb6e7b0a278f6665b # v2.0.2
         id: regex-match
         if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
@@ -25,14 +28,14 @@ jobs:
       - name: Break on invalid branch name
         run: exit 1
         if: ${{ github.event_name == 'workflow_dispatch' && steps.regex-match.outputs && steps.regex-match.outputs.match == '' }}
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: ${{ matrix.node }}
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v3
+      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: v1/${{ runner.os }}/node-${{ matrix.node }}/${{ hashFiles('**/yarn.lock') }}
@@ -40,16 +43,19 @@ jobs:
       - run: yarn
       - name: Set up @percy/cli from git
         if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          CLI_BRANCH: ${{ github.event.inputs.branch }}
+          WORKSPACE: ${{ github.workspace }}
         run: |
           cd /tmp
-          git clone --branch ${{ github.event.inputs.branch }} --depth 1 https://github.com/percy/cli
+          git clone --branch "$CLI_BRANCH" --depth 1 https://github.com/percy/cli
           cd cli
           PERCY_PACKAGES=`find packages -mindepth 1 -maxdepth 1 -type d | sed -e 's/packages/@percy/g' | tr '\n' ' '`
           git log -1
           yarn
           yarn build
           yarn global:link
-          cd ${{ github.workspace }} 
+          cd "$WORKSPACE"
           yarn remove @percy/cli && yarn link `echo $PERCY_PACKAGES`
           npx percy --version
       - run: yarn test:coverage

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,18 +1,21 @@
 name: Typecheck
 on: push
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: 14
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v3
+      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: v1/${{ runner.os }}/node-14/${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
## Summary
Breaks the percy-puppeteer supply-chain chains (deadline 2026-06-21), all of which enter through CI weaknesses:

| Chain | Entry |
|-------|-------|
| [PER-8741](https://browserstack.atlassian.net/browse/PER-8741) (C-001) | Floating-tag action compromise → NPM_TOKEN exfil → backdoored `@percy/puppeteer` |
| [PER-8742](https://browserstack.atlassian.net/browse/PER-8742) (C-002) | `workflow_dispatch` branch input → CVE-2023-45133 in nyc/@babel/traverse |
| [PER-8743](https://browserstack.atlassian.net/browse/PER-8743) (C-003) | `workflow_dispatch` shell injection → NPM_TOKEN via over-scoped GITHUB_TOKEN |

## Changes
- **SHA-pin** every action (`checkout`, `setup-node`, `cache`, `release-drafter`, `action-regex-match`, `stale`).
- **Least-privilege `permissions`** on every workflow (top-level `contents: read`; `changelog` → contents/PR write; `stale` → issues/PR write).
- **Env-bind + quote** the `workflow_dispatch` branch input in `test.yml` — closes the branch-name shell-injection (C-002/C-003).

## Verification
All 7 workflow YAMLs parse; zero unpinned `uses:`; every workflow declares `permissions:`; dispatch branch no longer interpolated inline.

> The `@babel/traverse` CVE foothold of C-002 is a dev/build transitive dep; the CI hardening removes the publish-escalation that makes the chain High. The dep bump is a flagged build-tree follow-up.

Closes the CI entry of PER-8741/8742/8743.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PER-8741]: https://browserstack.atlassian.net/browse/PER-8741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PER-8742]: https://browserstack.atlassian.net/browse/PER-8742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PER-8743]: https://browserstack.atlassian.net/browse/PER-8743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ