### PR TITLE
test: stop readiness spy from matching the @percy/dom bundle injection

### DIFF
--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -92,9 +92,19 @@ describe('percySnapshot', () => {
   });
 
   describe('readiness gate', () => {
-    // The readiness call sends a STRING script (from sdk-utils.waitForReadyScript);
-    // serialize sends a FUNCTION reference. That difference lets us identify each call.
-    const isReadinessEval = (args) => typeof args[0] === 'string' && args[0].includes('PercyDOM.waitForReady');
+    // percySnapshot makes three page.evaluate calls:
+    //   1. injecting the @percy/dom bundle  — a STRING that *defines* PercyDOM
+    //      (and, on readiness-capable CLIs, includes a `PercyDOM.waitForReady` definition)
+    //   2. the readiness gate                — a STRING from sdk-utils.waitForReadyScript
+    //      that *calls* PercyDOM.waitForReady(<config>)
+    //   3. serialize                         — a FUNCTION reference
+    // Both (1) and (2) are strings containing "PercyDOM.waitForReady", so a bare
+    // substring match would mis-identify the bundle injection as the readiness eval.
+    // The bundle additionally contains "serializeDOM"; the readiness script never does,
+    // so we exclude it to target the readiness eval specifically.
+    const isReadinessScript = (s) =>
+      typeof s === 'string' && s.includes('PercyDOM.waitForReady') && !s.includes('serializeDOM');
+    const isReadinessEval = (args) => isReadinessScript(args[0]);
     const isSerializeEval = (args) => typeof args[0] === 'function' && args[0].toString().includes('PercyDOM.serialize');
 
     it('runs waitForReady before serialize by default', async () => {
@@ -137,7 +147,7 @@ describe('percySnapshot', () => {
     it('still runs serialize when waitForReady rejects', async () => {
       const origEvaluate = page.evaluate.bind(page);
       spyOn(page, 'evaluate').and.callFake((script, ...rest) => {
-        if (typeof script === 'string' && script.includes('PercyDOM.waitForReady')) {
+        if (isReadinessScript(script)) {
           return Promise.reject(new Error('readiness boom'));
         }
         return origEvaluate(script, ...rest);
@@ -155,7 +165,7 @@ describe('percySnapshot', () => {
       // has no `.message`, so logging falls through to stringifying err itself.
       const origEvaluate = page.evaluate.bind(page);
       spyOn(page, 'evaluate').and.callFake((script, ...rest) => {
-        if (typeof script === 'string' && script.includes('PercyDOM.waitForReady')) {
+        if (isReadinessScript(script)) {
           return Promise.reject('plain-string-rejection');
         }
         return origEvaluate(script, ...rest);
@@ -172,7 +182,7 @@ describe('percySnapshot', () => {
       const diagnostics = { passed: true, timed_out: false, preset: 'balanced', total_duration_ms: 84, checks: {} };
       const domSnapshot = { html: '<html></html>' };
       spyOn(page, 'evaluate').and.callFake((script) => {
-        if (typeof script === 'string' && script.includes('PercyDOM.waitForReady')) {
+        if (isReadinessScript(script)) {
           return Promise.resolve(diagnostics);
         }
         if (typeof script === 'function' && script.toString().includes('PercyDOM.serialize')) {


### PR DESCRIPTION
## Problem

The `readiness gate` specs identify the readiness `page.evaluate` call by the substring `PercyDOM.waitForReady`. But `percySnapshot` makes an **earlier** `page.evaluate` that injects the whole `@percy/dom` bundle (`utils.fetchPercyDOM()`), and on readiness-capable CLIs that bundle **defines** `PercyDOM.waitForReady` — so the bare substring match *also* matched the bundle-injection call.

When a spy rejected/intercepted that first call, the rejection propagated to the SDK's outer `catch` (`Could not take DOM snapshot "..."`), failing 4 readiness specs:
- inlines the readiness config as JSON into the script sent to the browser
- skips waitForReady when preset is disabled
- still runs serialize when waitForReady rejects
- still runs serialize when waitForReady rejects with a non-Error

### Why it only shows up against CLI master
This repo's `yarn.lock` pins `@percy/cli`/`@percy/dom` at **1.16.0** (pre-readiness), whose `/percy/dom.js` contains no `waitForReady` — so the substring never false-matched and the specs passed (vacuously). Running against a readiness-capable CLI (master, or any 1.31.15+/1.32.x) serves a bundle that *does* contain `waitForReady`, exposing the collision. Verified: master `/percy/dom.js` contains `PercyDOM.waitForReady` (and `serializeDOM`); 1.16.0 contains neither.

## Fix

Narrow the matcher to the readiness script specifically. The generated readiness script *calls* `PercyDOM.waitForReady(<config>)` but — unlike the `@percy/dom` bundle — never contains `serializeDOM`. A shared `isReadinessScript()` predicate now backs `isReadinessEval` and the three `callFake` spies.

```js
const isReadinessScript = (s) =>
  typeof s === 'string' && s.includes('PercyDOM.waitForReady') && !s.includes('serializeDOM');
```

Verified against master sdk-utils: the generated readiness script classifies as readiness (`true`), the real ~105 KB dom bundle does not (`false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)