### PR TITLE
chore: bump version to 2.0.3-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/puppeteer",
   "description": "Pupppeteer client library for visual testing with Percy",
-  "version": "2.0.3-beta.1",
+  "version": "2.0.3-beta.2",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-puppeteer",


### PR DESCRIPTION
Version bump to `2.0.3-beta.2` to release the merged CORS-iframe + closed-shadow-DOM work (PER-7292).

Bumps `2.0.3-beta.1` → `2.0.3-beta.2` (next beta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)