### PR TITLE
chore: release 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/puppeteer",
   "description": "Pupppeteer client library for visual testing with Percy",
-  "version": "2.0.3-beta.3",
+  "version": "2.0.3",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-puppeteer",


### PR DESCRIPTION
Promotes the PER-8053 config-merge work from `2.0.3-beta.3` to stable `2.0.3`. Config is deep-merged into serializeDOM (per-call priority); verified via the cross-SDK sanity sweep.

Note: a pre-staged **draft** `v2.0.3` release exists (no git tag yet) — publish/replace it at release time.